### PR TITLE
Optional input of txt file that contains telbam file paths

### DIFF
--- a/telomerecat/telbam2length.py
+++ b/telomerecat/telbam2length.py
@@ -901,7 +901,7 @@ class Telbam2Length(TelomerecatInterface):
                         telbams_paths.append(line.strip())
         else:  # input is already a list of telbam paths
             telbams_paths = self.cmd_args.input
-
+        print telbam_paths
         self.run(input_paths=telbams_paths,
                  trim=self.cmd_args.trim,
                  output_path=self.cmd_args.output,

--- a/telomerecat/telbam2length.py
+++ b/telomerecat/telbam2length.py
@@ -893,7 +893,16 @@ class Telbam2Length(TelomerecatInterface):
             cmd_run=cmd_run)
 
     def run_cmd(self):
-        self.run(input_paths=self.cmd_args.input,
+        if self.cmd_args.file_input:  # input is txt files containing telbam paths
+            telbams_paths = []
+            for file in self.cmd_args.input:
+                with open(file, 'rb') as f:
+                    for line in f:
+                        telbams_paths.append(line.strip())
+        else:  # input is already a list of telbam paths
+            telbams_paths = self.cmd_args.input
+
+        self.run(input_paths=telbams_paths,
                  trim=self.cmd_args.trim,
                  output_path=self.cmd_args.output,
                  simulator_n=self.cmd_args.simulator_runs,
@@ -1086,6 +1095,11 @@ class Telbam2Length(TelomerecatInterface):
         parser.add_argument(
             'input', metavar='TELBAM(S)', nargs='+',
             help="The TELBAM(s) that we wish to analyse")
+        # file_input
+        parser.add_argument(
+            '-i', '--file_input', action="store_true", default=False,
+            help="Specify whether the input file is a telbam or a txt file\n"
+                    "that contains one telbam file per row")
         parser.add_argument(
             '--output', metavar='CSV', type=str, nargs='?', default=None,
             help=('Specify output path for length estimation CSV.\n'

--- a/telomerecat/telbam2length.py
+++ b/telomerecat/telbam2length.py
@@ -901,7 +901,7 @@ class Telbam2Length(TelomerecatInterface):
                         telbams_paths.append(line.strip())
         else:  # input is already a list of telbam paths
             telbams_paths = self.cmd_args.input
-        print telbam_paths
+
         self.run(input_paths=telbams_paths,
                  trim=self.cmd_args.trim,
                  output_path=self.cmd_args.output,

--- a/telomerecat/telbam2length.py
+++ b/telomerecat/telbam2length.py
@@ -897,8 +897,9 @@ class Telbam2Length(TelomerecatInterface):
             telbams_paths = []
             for file in self.cmd_args.input:
                 with open(file, 'rb') as f:
-                    for line in f:
-                        telbams_paths.append(line.strip())
+                    lines = [line.strip() for line in f]
+                    telbams_paths.extend(lines)
+                
         else:  # input is already a list of telbam paths
             telbams_paths = self.cmd_args.input
 


### PR DESCRIPTION
I want to run `telbam2length` on many telbams at once with the `-e` F2a flag enabled but I was exceeding the maximal command line argument length ([`ARG_MAX`](https://stackoverflow.com/questions/19354870/bash-command-line-and-input-limit)) when having to concatenate all my input telbam paths into a string. This fix adds an optional parameter which enables one to pass a `txt` file as input where each line of the `txt` file contains the path of a telbam file. Such a format is consistent with the `-b` flag in [`samtools merge`](http://www.htslib.org/doc/samtools-merge.1.html).